### PR TITLE
Single source of truth for version number

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -85,6 +85,10 @@ const common = {
     new webpack.ProvidePlugin({
       process: 'process/browser',
     }),
+    // Let us use the version from package.json in our code
+    new webpack.DefinePlugin({
+      VERSION: JSON.stringify(require("../package.json").version)
+    })
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "edge-workspaces",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Edge workspaces for Chrome",
   "private": true,
   "scripts": {
+    "prebuild": "node scripts/sync-version.js",
     "watch": "node ./node_modules/webpack/bin/webpack.js --mode=development --watch --config config/webpack.config.js",
     "build": "node ./node_modules/webpack/bin/webpack.js --mode=production --config config/webpack.config.js",
     "build-copy": "npm run build && cp -rf ./build/* ../chrome-edge-workspaces.vscode/test-build",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Edge Workspaces",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Edge Workspaces is a Chrome extension that helps you manage your tabs.",
   "icons": {
     "16": "icons/icon_16.png",
@@ -20,7 +20,6 @@
     "service_worker": "background.js",
     "type": "module"
   },
-
   "permissions": [
     "storage",
     "tabGroups",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,13 @@
+/**
+ * This script updates the version in the manifest.json file with the version from package.json.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const packageJson = require('../package.json');
+const manifestPath = path.join(__dirname, '..', 'public', 'manifest.json');
+const manifest = require(manifestPath);
+
+manifest.version = packageJson.version;
+
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,0 +1,3 @@
+declare const VERSION: string;
+const _version = VERSION;
+export { _version as VERSION };

--- a/src/pages/page-settings.ts
+++ b/src/pages/page-settings.ts
@@ -1,4 +1,5 @@
 import { BaseDialog } from "../dialogs/base-dialog";
+import { VERSION } from "../globals";
 import { LogHelper } from "../log-helper";
 import { PopupActions } from "../popup-actions";
 import SETTINGS_TEMPLATE from "../templates/settingsModalTemplate.html";
@@ -15,7 +16,7 @@ export class PageSettings extends BaseDialog {
      * This method creates the dialog element, attaches event listeners, and shows the dialog.
      */
     public static openSettings() {
-        const dialog = Utils.interpolateTemplate(SETTINGS_TEMPLATE, {});
+        const dialog = Utils.interpolateTemplate(SETTINGS_TEMPLATE, {"version": VERSION});
 
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = dialog;

--- a/src/templates/settingsModalTemplate.html
+++ b/src/templates/settingsModalTemplate.html
@@ -1,5 +1,5 @@
 <dialog class="modal" id="modal">
-    <h2>Settings</h2>
+    <h2>Extension Settings (v${version})</h2>
     <input id="modal-settings-new-workspace-from-window" type="button" value="New workspace from window" />
     <br />
     <div class="modal-settings-bottom">


### PR DESCRIPTION
Take the extension version from `package.json` as the source of truth.
* Add a script to update `manifest.json`'s version from it on prebuild.
* Add version number to Settings modal
