### PR TITLE
Handle detaching tabs from workspace windows better

### DIFF
--- a/src/test/e2e/basic-workflow.test.ts
+++ b/src/test/e2e/basic-workflow.test.ts
@@ -1,5 +1,3 @@
-import { Constants } from "../../constants/constants";
-import { StorageHelper } from "../../storage-helper";
 import { E2ECommon } from "./utils/e2e-common";
 
 let common: E2ECommon;
@@ -121,8 +119,7 @@ test("creating a new workspace from the current window adds it to the list with 
         const newPage = await common.browser.newPage();
         await newPage.goto(url, { waitUntil: 'domcontentloaded' });
     }
-
-    page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+    
     // Switch to the popup page
     await page.bringToFront();
 

--- a/src/test/jest/mock-extension-apis.js
+++ b/src/test/jest/mock-extension-apis.js
@@ -31,5 +31,8 @@ global.chrome = {
         onMessage: {
             addListener: () => { jest.fn(); }
         }
+    },
+    action: {
+        setBadgeText: jest.fn()
     }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,10 +18,7 @@ export class Utils {
     public static async setBadgeForWindow(windowId: number, text: string, color?: string | chrome.action.ColorArray): Promise<void> {
         const tabs = await this.getTabsFromWindow(windowId);
         for (const tab of tabs) {
-            chrome.action.setBadgeText({ text: text, tabId: tab.id });
-            if (color !== undefined) {
-                chrome.action.setBadgeBackgroundColor({ color: color, tabId: tab.id });
-            }
+            this.setBadgeForTab(text, tab.id, color);
         }
     }
 
@@ -31,7 +28,17 @@ export class Utils {
     public static async clearBadgeForWindow(windowId: number): Promise<void> {
         const tabs = await this.getTabsFromWindow(windowId);
         for (const tab of tabs) {
-            chrome.action.setBadgeText({ text: "", tabId: tab.id });
+            this.setBadgeForTab("", tab.id);
+        }
+    }
+
+    /**
+     * Sets the extension badge text for a tab.
+     */
+    public static async setBadgeForTab(text: string, tabId?: number, color?: string | chrome.action.ColorArray): Promise<void> {
+        chrome.action.setBadgeText({ text: text, tabId: tabId });
+        if (color !== undefined) {
+            chrome.action.setBadgeBackgroundColor({ color: color, tabId: tabId });
         }
     }
 


### PR DESCRIPTION
* Ensure the extension badge text is cleared when a tab is specifically detached from a workspace.  
* Fixed misspelling
* Removed e2e test console logs

Closes #10 