### PR TITLE
Focus open workspace window instead of creating a new one

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -164,27 +164,23 @@ export class Background {
     }
 
     /**
-     * We need to update the workspace with the new window ID.
+     * This method is called after the client has opened a new window with the workspace's tabs.
      * 
-     * Then we need to send a message back to the content script with the updated workspace.
+     * We need to update the workspace with the new window ID.
+     * Also clear the workspace's tabs, since more are about to be opened in a new window.
+     * 
+     * 
      * @param uuid - The UUID of the workspace to open.
      * @param windowId - The ID of the window that the workspace is being opened in.
      * @returns 
      */
-    public static async openWorkspace(uuid: string, windowId: number): Promise<MessageResponse> {
+    public static async updateWorkspaceWindowId(uuid: string, windowId: number): Promise<MessageResponse> {
         try {
             const workspace = await StorageHelper.getWorkspace(uuid);
             workspace.windowId = windowId;
-            // Serialize the workspace before we make any other changes
-            const data = workspace.serialize();
-
-            // The workspace is just about to get a bunch of tabs opened.
-            // The tabs are going to have unique IDs again, so we need to clear the tabs map
-            // to avoid duplicate tabs.
-            workspace.clearTabs();
             await StorageHelper.setWorkspace(workspace);
+            return MessageResponses.SUCCESS;
 
-            return { "data": data };
         }
         catch (error) {
             LogHelper.errorAlert(error as string);

--- a/src/messages/background-message-handlers.ts
+++ b/src/messages/background-message-handlers.ts
@@ -21,7 +21,7 @@ export class BackgroundMessageHandlers {
             return MessageResponses.ERROR;
         }
 
-        return await Background.openWorkspace(request.payload.uuid, request.payload.windowId);
+        return await Background.updateWorkspaceWindowId(request.payload.uuid, request.payload.windowId);
     }
 
     /**

--- a/src/test/jest/mock-extension-apis.js
+++ b/src/test/jest/mock-extension-apis.js
@@ -15,7 +15,9 @@ global.chrome = {
         },
         onCreated: {
             addListener: () => { jest.fn(); }
-        }
+        },
+        update: jest.fn(),
+        get: jest.fn()
     },
     tabs: {
         onRemoved: {

--- a/src/test/unit/background-message-handlers.test.js
+++ b/src/test/unit/background-message-handlers.test.js
@@ -2,8 +2,6 @@ import { Background } from "../../background";
 import { MessageResponses } from "../../constants/message-responses";
 import { Messages } from "../../constants/messages";
 import { BackgroundMessageHandlers } from "../../messages/background-message-handlers";
-import { TabStub } from "../../obj/tab-stub";
-import { Workspace } from "../../obj/workspace";
 import { StorageHelper } from "../../storage-helper";
 
 
@@ -136,9 +134,7 @@ describe("BackgroundMessageHandlers", () => {
 
             expect(StorageHelper.getWorkspace).toHaveBeenCalledWith('123');
             expect(mockWorkspace.windowId).toBe(1);
-            expect(mockWorkspace.clearTabs).toHaveBeenCalled();
             expect(StorageHelper.setWorkspace).toHaveBeenCalledWith(mockWorkspace);
-            expect(response).toEqual({ data: 'serialized data' });
         });
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,32 @@ import { StorageHelper } from "./storage-helper";
  */
 export class Utils {
     /**
+     * Retrieves a Chrome window by its ID.
+     * @param windowId - The ID of the window to retrieve.
+     * @returns A Promise that resolves with the retrieved window, or undefined if not found.
+     */
+    public static async getWindowById(windowId: number): Promise<chrome.windows.Window | undefined> {
+        return new Promise((resolve) => {
+            chrome.windows.get(windowId).then((window) => {
+                resolve(window);
+            })
+            // If the window is not found, the promise will still resolve, just with an undefined value.
+            // Catch the error to prevent the console from logging it.
+            .catch(() => {
+                resolve(undefined);
+            });
+        });
+    }
+
+    /**
+     * Focuses a Chrome window by its ID.
+     * @param windowId - The ID of the window to focus.
+     */
+    public static async focusWindow(windowId: number): Promise<void> {
+        chrome.windows.update(windowId, { focused: true });
+    }
+
+    /**
      * Sets the extension badge text for all tabs in a window.
      * 
      * There are only two options for badge text: per tab and globally. We can't set the badge text for a window, 


### PR DESCRIPTION
Closes #4 
* When an already open workspace is clicked, it will now switch to that window.
* Rename Background.openWorkspace to updateWorkspaceWindowId
  * We no longer open the workspace via the background script, so this is cleaning up old code.