### PR TITLE
Add validation for empty workspace name

### DIFF
--- a/src/pages/page-add-workspace.ts
+++ b/src/pages/page-add-workspace.ts
@@ -93,6 +93,10 @@ export class PageAddWorkspace extends BaseDialog {
             console.debug("New workspace prompt cancelled");
             return;
         }
+        if (workspaceName === "") {
+            LogHelper.errorAlert("Workspace name cannot be empty");
+            return;
+        }
         // Get the current window ID
         const currentWindow = await chrome.windows.getCurrent();
         if (currentWindow === undefined || currentWindow.id === undefined) {

--- a/src/popup.css
+++ b/src/popup.css
@@ -68,7 +68,7 @@ html {
 
 body {
     width: 350px;
-    min-height: 120px;
+    min-height: 150px;
     /* height: 300px; */
 
     color: var(--on-surface-color);
@@ -253,6 +253,10 @@ Make the input buttons inside the modal look like a modern button
     border-radius: 5px;
     cursor: pointer;
     align-self: center;
+}
+
+#modal-input-name {
+    margin-top: 3px;
 }
 
 ::backdrop {


### PR DESCRIPTION
Don't create a new workspace if there is a blank name input. It would likely cause problems.

Increase minimum height to compensate for the added padding with the new styled buttons.