### PR TITLE
Improve performance by limiting excess saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-workspaces",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Edge workspaces for Chrome",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Edge Workspaces",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Edge Workspaces is a Chrome extension that helps you manage your tabs.",
   "icons": {
     "16": "icons/icon_16.png",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -5,4 +5,12 @@ export class Constants {
     public static BOOKMARKS_FOLDER_NAME = "Tab Manager";
 
     public static DOWNLOAD_FILENAME = "workspaces-export.json";
+
+    /** Time in seconds to delay saving a workspace after it has been opened. */
+    public static WORKSPACE_OPEN_SAVE_DELAY = 5;
+
+    /** Time in ms to debounce the saving of the workspace on updates. */
+    public static WORKSPACE_SAVE_DEBOUNCE_TIME = 300;
+
+    public static DEBOUNCE_ALARM_NAME_PREFIX = "debounceSave";
 }

--- a/src/test/jest/mock-extension-apis.js
+++ b/src/test/jest/mock-extension-apis.js
@@ -1,7 +1,4 @@
 global.chrome = {
-    tabs: {
-        query: async () => { throw new Error("Unimplemented.") }
-    },
     storage: {
         local: {
             get: async () => { throw new Error("Unimplemented.") },
@@ -28,6 +25,9 @@ global.chrome = {
         },
         query: jest.fn(),
         get: jest.fn()
+    },
+    tabGroups: {
+        query: jest.fn()
     },
     runtime: {
         onMessage: {

--- a/src/test/unit/background-message-handlers.test.js
+++ b/src/test/unit/background-message-handlers.test.js
@@ -113,7 +113,7 @@ describe("BackgroundMessageHandlers", () => {
             expect(response).toEqual(MessageResponses.ERROR);
         });
 
-        it('should get the workspace, update it, clear its tabs, and return the serialized data', async () => {
+        it('should get the workspace, update it, clear its tabs, and return the seralized data', async () => {
             const request = {
                 payload: {
                     uuid: '123',

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,23 @@
+import { Utils } from "../utils";
+
+export class DebounceUtil {
+    private static debounceTimeout: NodeJS.Timeout | undefined;
+    
+    /**
+     * Debounce the saving of the workspace.
+     * @param windowId - The ID of the window to save the workspace for.
+     * @param delay - The delay in ms to debounce the save.
+     */
+    public static debounce(callback: () => void, delay: number): void {
+        if (DebounceUtil.debounceTimeout) {
+            clearTimeout(DebounceUtil.debounceTimeout);
+        }
+        // If we're testing with Jest, don't debounce, since we probably test the function immediately.
+        if (Utils.areWeTestingWithJest()) {
+            callback();
+            return;
+        }
+
+        DebounceUtil.debounceTimeout = setTimeout(callback, delay);
+    }
+}


### PR DESCRIPTION
Since the background script listens for tab updated events, when a workspace is opened all of the tabs opening and loading trigger the whole saving workflow.

When opening a workspace with ~17 tabs, I can clearly feel the browser lagging.

Closes #22 