### PR TITLE
Save copy of workspaces to bookmarks folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - **Automatic Saving**: The extension automatically saves your workspace as you work, eliminating the need to manually save open tabs.
 - **Import/Export**: Workspaces can be exported to a file and imported later on another device.
+- **Workspaces copied as bookmarks**: Workspaces can be saved as bookmarks to allow for easier cross-platform access.
 - **Internal Tab Exclusion**: Internal tabs, such as the new tab page, settings, or extensions, are not saved to workspaces.
 
 ## Usage
@@ -36,6 +37,13 @@
 
 - Click the trashcan icon to delete a workspace.
 - Click the pencil icon to rename a workspace.
+
+### Saving Workspaces as Bookmarks
+
+- Ensure "Save workspaces to bookmarks" option is checked in Settings.
+- Workspaces will now be copied to `Other bookmarks -> Edge Workspaces (read-only) -> [Workspace Name]`.
+- Note that changes to the bookmarks will **not** be reflected in the workspaces themselves, as they are just a copy. 
+- When installing a new version, make sure to open old workspaces at least once to allow for them to be saved as bookmarks.
 
 ### Importing/Exporting Workspaces
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-workspaces",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Edge workspaces extension",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Edge Workspaces",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Effortlessly organize and manage multiple projects or tasks by saving and restoring entire browsing sessions.",
   "icons": {
     "16": "icons/icon_16.png",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,8 @@
   "permissions": [
     "storage",
     "tabGroups",
-    "activeTab"
+    "activeTab",
+    "bookmarks"
   ],
   "browser_specific_settings": {
     "gecko": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -231,7 +231,8 @@ export class Background {
         Utils.setBadgeForWindow(windowId, Background.getBadgeTextForWorkspace(workspace));
 
         // Ensure the workspace is saved to bookmarks
-        BookmarkStorageHelper.saveWorkspace(workspace)
+        console.debug(`Saving workspace ${ workspace.name } to bookmarks...`);
+        await BookmarkStorageHelper.saveWorkspace(workspace)
 
         // Save the workspace to sync storage
         // await StorageHelper.setWorkspace(workspace);

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import { LogHelper } from "./log-helper";
 import { BackgroundMessageHandlers } from "./messages/background-message-handlers";
 import { Workspace } from "./obj/workspace";
 import { StorageHelper } from "./storage-helper";
+import { BookmarkStorageHelper } from "./storage/bookmark-storage-helper";
 import { Utils } from "./utils";
 import { DebounceUtil } from "./utils/debounce";
 import { FeatureDetect } from "./utils/feature-detect";
@@ -229,7 +230,11 @@ export class Background {
         // Update the badge text
         Utils.setBadgeForWindow(windowId, Background.getBadgeTextForWorkspace(workspace));
 
-        // await BookmarkStorageHelper.addTabToWorkspace(workspace.uuid, tab);
+        // Ensure the workspace is saved to bookmarks
+        BookmarkStorageHelper.saveWorkspace(workspace)
+
+        // Save the workspace to sync storage
+        // await StorageHelper.setWorkspace(workspace);
     }
 
     /**

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,7 +2,10 @@
 export class Constants {
     public static KEY_STORAGE_WORKSPACES = "workspaces";
     
-    public static BOOKMARKS_FOLDER_NAME = "Tab Manager";
+    public static BOOKMARKS_FOLDER_NAME = "Edge Workspaces";
+
+    /** The name for 'Other bookmarks' */
+    public static BOOKMARKS_OTHER_NAME = "Other bookmarks";
 
     public static DOWNLOAD_FILENAME = "workspaces-export.json";
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,10 +2,7 @@
 export class Constants {
     public static KEY_STORAGE_WORKSPACES = "workspaces";
 
-    public static BOOKMARKS_FOLDER_NAME = "Edge Workspaces";
-
-    /** The name for 'Other bookmarks' */
-    public static BOOKMARKS_OTHER_NAME = "Other bookmarks";
+    public static BOOKMARKS_FOLDER_NAME = "Edge Workspaces (read-only)";
 
     public static DOWNLOAD_FILENAME = "workspaces-export.json";
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,7 +1,7 @@
 
 export class Constants {
     public static KEY_STORAGE_WORKSPACES = "workspaces";
-    
+
     public static BOOKMARKS_FOLDER_NAME = "Edge Workspaces";
 
     /** The name for 'Other bookmarks' */
@@ -16,4 +16,10 @@ export class Constants {
     public static WORKSPACE_SAVE_DEBOUNCE_TIME = 300;
 
     public static DEBOUNCE_ALARM_NAME_PREFIX = "debounceSave";
+
+    public static STORAGE_KEYS = {
+        settings: {
+            saveBookmarks: "settings.saveBookmarks",
+        }
+    }
 }

--- a/src/messages/background-message-handlers.ts
+++ b/src/messages/background-message-handlers.ts
@@ -4,6 +4,7 @@ import { StorageHelper } from "../storage-helper";
 import { Background } from "../background";
 import { MessageResponse, MessageResponses } from "../constants/message-responses";
 import { Utils } from "../utils";
+import { BookmarkStorageHelper } from "../storage/bookmark-storage-helper";
 
 /**
  * Class representing the message handlers for background operations.
@@ -67,6 +68,10 @@ export class BackgroundMessageHandlers {
         }
 
         const result = await StorageHelper.removeWorkspace(request.payload.uuid);
+
+        // Remove the workspace from bookmarks
+        await BookmarkStorageHelper.removeWorkspace(workspace);
+        
         if (!result) {
             return MessageResponses.ERROR;
         }

--- a/src/pages/page-settings.ts
+++ b/src/pages/page-settings.ts
@@ -4,6 +4,7 @@ import { BaseDialog } from "../dialogs/base-dialog";
 import { VERSION } from "../globals";
 import { LogHelper } from "../log-helper";
 import { StorageHelper } from "../storage-helper";
+import { BookmarkStorageHelper } from "../storage/bookmark-storage-helper";
 import SETTINGS_TEMPLATE from "../templates/dialogSettingsTemplate.html";
 import { Utils } from "../utils";
 
@@ -21,8 +22,14 @@ export class PageSettings extends BaseDialog {
      * Opens the settings dialog.
      * This method creates the dialog element, attaches event listeners, and shows the dialog.
      */
-    public static openSettings() {
-        const dialog = Utils.interpolateTemplate(SETTINGS_TEMPLATE, {"version": VERSION});
+    public static async openSettings() {
+        const saveBookmarks = await BookmarkStorageHelper.isBookmarkSaveEnabled();
+        const dialog = Utils.interpolateTemplate(SETTINGS_TEMPLATE, 
+            {
+                "version": VERSION,
+                "bookmarkSaveChecked": saveBookmarks ? "checked" : ""
+            }
+        );
 
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = dialog;
@@ -34,6 +41,10 @@ export class PageSettings extends BaseDialog {
         });
         dialogElement.querySelector("#modal-settings-import")?.addEventListener("click", () => {
             PageSettings.importSettings();
+        });
+        dialogElement.querySelector("#modal-settings-bookmark-save")?.addEventListener("click", async (event) => {
+            const target = event.target as HTMLInputElement;
+            await BookmarkStorageHelper.setBookmarkSaveEnabled(target.checked);
         });
 
         dialogElement.querySelector("#modal-settings-close")?.addEventListener("click", () => {

--- a/src/popup.css
+++ b/src/popup.css
@@ -84,6 +84,18 @@ body {
     cursor: pointer;
     align-self: center;
 }
+/* No margin bottom for checkboxes */
+input[type="checkbox"] {
+    margin-bottom: 0;
+}
+
+.settings-checkbox {
+    display: flex;
+    align-items: center;
+}
+.settings-checkbox label {
+    margin-left: 5px;
+}
 
 .sidebar {
     /* To override the width in body */

--- a/src/storage/bookmark-storage-helper.ts
+++ b/src/storage/bookmark-storage-helper.ts
@@ -1,7 +1,6 @@
 import { Constants } from "../constants/constants";
 import { Workspace } from "../obj/workspace";
 import { StorageHelper } from "../storage-helper";
-import { WorkspaceStorage } from "../workspace-storage";
 
 export class BookmarkStorageHelper {
     /**
@@ -59,13 +58,12 @@ export class BookmarkStorageHelper {
         }
 
         const resolvedBookmarkFolder = await bookmarkFolder;
+
         if (resolvedBookmarkFolder === undefined) {
             console.error("Could not find the bookmark folder, cannot save workspace to bookmarks.");
             return Promise.reject("Could not find the bookmark folder.");
         }
-        console.debug("saveWorkspaceBookmarks: ", workspace, resolvedBookmarkFolder);
         const workspaceFolder = resolvedBookmarkFolder.children?.find((node) => node.title === workspace.name);
-
         // Delete the workspace folder and all children so we can recreate it with the new tabs
         if (workspaceFolder !== undefined) {
             await chrome.bookmarks.removeTree(workspaceFolder.id);
@@ -84,19 +82,19 @@ export class BookmarkStorageHelper {
      * Remove the workspace from bookmarks.
      * @param workspace - The workspace to remove.
      */
-    public static async removeWorkspace(workspace: Workspace): Promise<void> {
+    public static async removeWorkspace(workspace: Workspace, bookmarkFolder = this.getExtensionBookmarkFolder()): Promise<void> {
         if (!await this.isBookmarkSaveEnabled()) {
             console.debug("Bookmark saving is disabled, skipping.");
             return;
         }
 
-        const resolvedBookmarkFolder = await this.getExtensionBookmarkFolder();
+        const resolvedBookmarkFolder = await bookmarkFolder;
         if (resolvedBookmarkFolder === undefined) {
-            console.error("Could not find the bookmark folder, cannot remove workspace from bookmarks.");
+            console.error("Could not find the bookmark folder, cannot save workspace to bookmarks.");
             return Promise.reject("Could not find the bookmark folder.");
         }
-
         const workspaceFolder = resolvedBookmarkFolder.children?.find((node) => node.title === workspace.name);
+
         if (workspaceFolder !== undefined) {
             await chrome.bookmarks.removeTree(workspaceFolder.id);
         }

--- a/src/storage/bookmark-storage-helper.ts
+++ b/src/storage/bookmark-storage-helper.ts
@@ -23,8 +23,8 @@ export class BookmarkStorageHelper {
 
     private static async createExtensionBookmarkFolder(otherBookmarksFolder: chrome.bookmarks.BookmarkTreeNode | undefined): Promise<chrome.bookmarks.BookmarkTreeNode> {
         if (otherBookmarksFolder === undefined) {
-            console.error(`Could not find the 'Other bookmarks' folder.`);
-            return Promise.reject(`Could not find the 'Other bookmarks' folder.`);
+            console.error("Could not find the 'Other bookmarks' folder.");
+            return Promise.reject("Could not find the 'Other bookmarks' folder.");
         }
         return await chrome.bookmarks.create({ parentId: otherBookmarksFolder.id, title: Constants.BOOKMARKS_FOLDER_NAME });
     }

--- a/src/templates/dialogSettingsTemplate.html
+++ b/src/templates/dialogSettingsTemplate.html
@@ -1,8 +1,13 @@
 <dialog class="modal" id="modal">
     <h2>Extension Settings (v${version})</h2>
     <br />
-    <input type="button" id="modal-settings-export" value="Export Data" />
-    <input type="button" id="modal-settings-import" value="Import Data" />
+    <div class="settings-checkbox">
+        <input type="checkbox" id="modal-settings-bookmark-save" ${bookmarkSaveChecked} />
+        <label for="modal-settings-bookmark-save">Save workspaces to bookmarks</label>
+    </div>
+    <br />
+    <input type="button" id="modal-settings-export" value="Export data to file" />
+    <input type="button" id="modal-settings-import" value="Import data from file" />
 
     <div class="modal-settings-bottom">
         <button id="modal-settings-close" class="close">Close</button>

--- a/src/test/unit/bookmark-storage-helper.test.js
+++ b/src/test/unit/bookmark-storage-helper.test.js
@@ -13,11 +13,16 @@ describe('BookmarkStorageHelper', () => {
                 getTree: jest.fn().mockResolvedValue([
                     {
                         id: '1',
-                        title: 'Bookmarks bar',
+                        title: '',
                         children: [
                             {
                                 id: '2',
-                                title: Constants.BOOKMARKS_OTHER_NAME,
+                                title: "Bookmarks bar",
+                                children: []
+                            },
+                            {
+                                id: '3',
+                                title: "Other bookmarks",
                                 children: []
                             }
                         ]
@@ -45,8 +50,8 @@ describe('BookmarkStorageHelper', () => {
     test('saveWorkspace should save the workspace bookmark folder correctly', async () => {
         const workspace = new Workspace(1, 'Test Workspace', []);
         await BookmarkStorageHelper.saveWorkspace(workspace);
-        
-        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Test Workspace', parentId: expect.any(String)});
+
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({ title: 'Test Workspace', parentId: expect.any(String) });
     });
 
     test('saveWorkspace should save the workspace bookmark tabs', async () => {
@@ -55,10 +60,10 @@ describe('BookmarkStorageHelper', () => {
             TabStub.fromTab({ id: '2', title: 'Tab 2', url: 'http://example2.com' })
         ]);
         await BookmarkStorageHelper.saveWorkspace(workspace);
-        
-        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Test Workspace', parentId: expect.any(String)});
-        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 1', url: 'http://example.com', parentId: expect.any(String)});
-        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 2', url: 'http://example2.com', parentId: expect.any(String)});
+
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({ title: 'Test Workspace', parentId: expect.any(String) });
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({ title: 'Tab 1', url: 'http://example.com', parentId: expect.any(String) });
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({ title: 'Tab 2', url: 'http://example2.com', parentId: expect.any(String) });
     });
 
     test('nothing should be saved to bookmarks when the setting is disabled', async () => {
@@ -73,7 +78,7 @@ describe('BookmarkStorageHelper', () => {
     describe("Remove workspace", () => {
         let workspace;
         let bookmarkFolder;
-    
+
         beforeEach(() => {
             workspace = new Workspace(1, "Test Workspace", []);
             bookmarkFolder = {
@@ -87,14 +92,20 @@ describe('BookmarkStorageHelper', () => {
                     }
                 ]
             };
-    
+
+            // Copy of the mocked structure from the start of the file
             jest.spyOn(chrome.bookmarks, "getTree").mockResolvedValue([{
-                id: "0",
-                title: "Bookmarks",
+                id: '1',
+                title: '',
                 children: [
                     {
-                        id: "1",
-                        title: Constants.BOOKMARKS_OTHER_NAME,
+                        id: '2',
+                        title: "Bookmarks bar",
+                        children: []
+                    },
+                    {
+                        id: '3',
+                        title: "Other bookmarks",
                         children: [bookmarkFolder]
                     }
                 ]
@@ -107,32 +118,32 @@ describe('BookmarkStorageHelper', () => {
 
         it("removeWorkspace removes the workspace folder if it exists", async () => {
             await BookmarkStorageHelper.removeWorkspace(workspace);
-    
+
             expect(chrome.bookmarks.removeTree).toHaveBeenCalledWith("2");
         });
-    
+
         test("removeWorkspace does nothing if the workspace folder does not exist", async () => {
             bookmarkFolder.children = [];
-    
+
             await BookmarkStorageHelper.removeWorkspace(workspace);
-    
+
             expect(chrome.bookmarks.removeTree).not.toHaveBeenCalled();
         });
-    
+
         test("removeWorkspace logs an error if the bookmark folder cannot be found", async () => {
-            jest.spyOn(console, "error").mockImplementation(() => {});
+            jest.spyOn(console, "error").mockImplementation(() => { });
             jest.spyOn(BookmarkStorageHelper, "getExtensionBookmarkFolder").mockResolvedValue(undefined);
-    
+
             await expect(BookmarkStorageHelper.removeWorkspace(workspace)).rejects.toEqual("Could not find the bookmark folder.");
-    
+
             expect(console.error).toHaveBeenCalled();
         });
-    
+
         test("removeWorkspace skips if bookmark saving is disabled", async () => {
             jest.spyOn(BookmarkStorageHelper, "isBookmarkSaveEnabled").mockResolvedValue(false);
-    
+
             await BookmarkStorageHelper.removeWorkspace(workspace);
-    
+
             expect(chrome.bookmarks.removeTree).not.toHaveBeenCalled();
         });
     });

--- a/src/test/unit/bookmark-storage-helper.test.js
+++ b/src/test/unit/bookmark-storage-helper.test.js
@@ -1,7 +1,7 @@
-import { BookmarkStorageHelper } from '../../storage/bookmark-storage-helper';
 import { Constants } from '../../constants/constants';
-import { Workspace } from '../../obj/workspace';
 import { TabStub } from "../../obj/tab-stub";
+import { Workspace } from '../../obj/workspace';
+import { BookmarkStorageHelper } from '../../storage/bookmark-storage-helper';
 
 jest.mock('../../storage-helper');
 
@@ -27,6 +27,8 @@ describe('BookmarkStorageHelper', () => {
                 search: jest.fn().mockResolvedValue([]),
             }
         };
+
+        jest.spyOn(BookmarkStorageHelper, "isBookmarkSaveEnabled").mockResolvedValue(true);
     });
 
     afterEach(() => {
@@ -56,5 +58,14 @@ describe('BookmarkStorageHelper', () => {
         expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Test Workspace', parentId: expect.any(String)});
         expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 1', url: 'http://example.com', parentId: expect.any(String)});
         expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 2', url: 'http://example2.com', parentId: expect.any(String)});
+    });
+
+    test('nothing should be saved to bookmarks when the setting is disabled', async () => {
+        jest.spyOn(BookmarkStorageHelper, "isBookmarkSaveEnabled").mockResolvedValue(false);
+
+        const workspace = new Workspace(1, 'Test Workspace', []);
+        await BookmarkStorageHelper.saveWorkspace(workspace);
+
+        expect(chrome.bookmarks.create).not.toHaveBeenCalled();
     });
 });

--- a/src/test/unit/bookmark-storage-helper.test.js
+++ b/src/test/unit/bookmark-storage-helper.test.js
@@ -1,0 +1,60 @@
+import { BookmarkStorageHelper } from '../../storage/bookmark-storage-helper';
+import { Constants } from '../../constants/constants';
+import { Workspace } from '../../obj/workspace';
+import { TabStub } from "../../obj/tab-stub";
+
+jest.mock('../../storage-helper');
+
+describe('BookmarkStorageHelper', () => {
+    beforeEach(() => {
+        // Mock chrome.bookmarks API
+        global.chrome = {
+            bookmarks: {
+                getTree: jest.fn().mockResolvedValue([
+                    {
+                        id: '1',
+                        title: 'Bookmarks bar',
+                        children: [
+                            {
+                                id: '2',
+                                title: Constants.BOOKMARKS_OTHER_NAME,
+                                children: []
+                            }
+                        ]
+                    }
+                ]),
+                create: jest.fn().mockImplementation((bookmark) => Promise.resolve({ id: '3', ...bookmark })),
+                search: jest.fn().mockResolvedValue([]),
+            }
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('getExtensionBookmarkFolder should retrieve or create the extension bookmark folder', async () => {
+        const folder = await BookmarkStorageHelper.getExtensionBookmarkFolder();
+        expect(folder).toBeDefined();
+        expect(folder?.title).toBe(Constants.BOOKMARKS_FOLDER_NAME);
+    });
+
+    test('saveWorkspace should save the workspace bookmark folder correctly', async () => {
+        const workspace = new Workspace(1, 'Test Workspace', []);
+        await BookmarkStorageHelper.saveWorkspace(workspace);
+        
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Test Workspace', parentId: expect.any(String)});
+    });
+
+    test('saveWorkspace should save the workspace bookmark tabs', async () => {
+        const workspace = new Workspace(1, 'Test Workspace', [
+            TabStub.fromTab({ id: '1', title: 'Tab 1', url: 'http://example.com' }),
+            TabStub.fromTab({ id: '2', title: 'Tab 2', url: 'http://example2.com' })
+        ]);
+        await BookmarkStorageHelper.saveWorkspace(workspace);
+        
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Test Workspace', parentId: expect.any(String)});
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 1', url: 'http://example.com', parentId: expect.any(String)});
+        expect(chrome.bookmarks.create).toHaveBeenCalledWith({title: 'Tab 2', url: 'http://example2.com', parentId: expect.any(String)});
+    });
+});


### PR DESCRIPTION
From a conversation on #5, I've taken a first step towards adding sync storage to the extension.
There is now an option to have the extension save a copy of the workspaces & tabs to `Other bookmarks -> Edge Workspaces (read-only)`.

**Important note:** Changes to the bookmarks inside the workspaces folder will **not** be reflected in the workspaces themselves. The bookmark folder is strictly a read-only copy.

This allows for access to the workspaces cross-device. I consider it a workaround for cross computer usage, but for mobile it will likely remain the only way to access workspaces.

**User setting**
![image](https://github.com/user-attachments/assets/de0e2fcc-b7f1-477d-88a7-de6b091b2098)

**Example bookmarks**
![image](https://github.com/user-attachments/assets/631c91e4-0361-437c-aa25-7d29f0967125)
