### PR TITLE
Save version number to storage during initialization

### DIFF
--- a/src/storage-helper.ts
+++ b/src/storage-helper.ts
@@ -1,5 +1,6 @@
 import { Constants } from "./constants/constants";
 import { MessageResponse } from "./constants/message-responses";
+import { VERSION } from "./globals";
 import { Workspace } from "./obj/workspace";
 import { WorkspaceStorage } from "./workspace-storage";
 
@@ -9,7 +10,7 @@ export class StorageHelper {
     private static _loadedWorkspaces: WorkspaceStorage = new WorkspaceStorage();
 
     public static async init() {
-
+        this.saveVersionNumber();
     }
 
     /** 
@@ -42,6 +43,14 @@ export class StorageHelper {
         chrome.storage.sync.set({ [key]: val }, function () {
             console.log(`Set ${ key }: ${ val }`);
         });
+    }
+
+    /**
+     * Save the version number to storage. This will be used to determine if the extension has been updated
+     * and if any migrations need to be run.
+     */
+    private static saveVersionNumber() {
+        this.setValue("version", VERSION);
     }
 
     /**

--- a/src/test/jest/mock-extension-apis.js
+++ b/src/test/jest/mock-extension-apis.js
@@ -2,7 +2,7 @@ global.chrome = {
     storage: {
         local: {
             get: async () => { throw new Error("Unimplemented.") },
-            set: async () => { throw new Error("Unimplemented.") },
+            set: async () => { jest.fn() },
             clear: async () => { throw new Error("Unimplemented.") }
         }
     },
@@ -38,3 +38,4 @@ global.chrome = {
         setBadgeText: jest.fn()
     }
 };
+global.VERSION = "1.0.0";


### PR DESCRIPTION
We'll use this in the future for migrations when we change the storage schema.