### PR TITLE
Show currently open workspaces as bold + always show hamburger menu

### DIFF
--- a/public-flavors/chrome/popup.html
+++ b/public-flavors/chrome/popup.html
@@ -22,7 +22,7 @@
     <div id="workspaces-list" class="workspaces">
       <!-- Whatever is here will be removed once the workspaces list loads -->
        If you see this message, it means that the workspaces list is still loading.<br>
-       If this message persists, please file a bug report <a href="https://github.com/Elec0/chrome-edge-workspaces/issues/new">here</a>.
+       If this message persists, please file a bug report <a href="https://github.com/Elec0/chrome-edge-workspaces/issues/new?template=bug_report.md">here</a>.
     </div>
 
   </div>

--- a/src/popup-actions.ts
+++ b/src/popup-actions.ts
@@ -28,7 +28,7 @@ export class PopupActions {
     private static async handleNewWorkspaceResponse(response: MessageResponse, windowId: number): Promise<void> {
         if (response.message === MessageResponses.SUCCESS.message) {
             console.debug("Workspace added successfully, refreshing list");
-            WorkspaceEntryLogic.listWorkspaces(await getWorkspaceStorage());
+            WorkspaceEntryLogic.listWorkspaces(await getWorkspaceStorage(), await Utils.getAllWindowIds());
         }
         else {
             LogHelper.errorAlert("Workspace could not be added\n" + response.message);
@@ -108,6 +108,8 @@ export class PopupActions {
                 return;
             }
             // We don't need to do anything with the response, since all the data should now be in sync
+            // Update the workspace list
+            WorkspaceEntryLogic.listWorkspaces(await getWorkspaceStorage(), await Utils.getAllWindowIds());
 
         });
     }
@@ -174,7 +176,7 @@ export class PopupActions {
         PopupMessageHelper.sendClearWorkspaces().then(async response => {
             if (response.message === MessageResponses.SUCCESS.message) {
                 LogHelper.successAlert("Workspace data cleared.");
-                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces());
+                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces(), await Utils.getAllWindowIds());
             }
             else {
                 LogHelper.errorAlert("Error clearing workspace data. Check the console for more details.");
@@ -193,7 +195,7 @@ export class PopupActions {
         PopupMessageHelper.sendDeleteWorkspace(workspace.uuid).then(async response => {
             if (response.message === MessageResponses.SUCCESS.message) {
                 console.log("Workspace deleted", workspace);
-                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces());
+                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces(), await Utils.getAllWindowIds());
             }
             else {
                 LogHelper.errorAlert("Error deleting workspace. Check the console for more details.");
@@ -212,7 +214,7 @@ export class PopupActions {
         PopupMessageHelper.sendRenameWorkspace(workspace.uuid, newName).then(async response => {
             if (response.message === MessageResponses.SUCCESS.message) {
                 console.log("Workspace renamed", workspace);
-                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces());
+                WorkspaceEntryLogic.listWorkspaces(await StorageHelper.getWorkspaces(), await Utils.getAllWindowIds());
             }
             else {
                 LogHelper.errorAlert("Error renaming workspace. Check the console for more details.");

--- a/src/popup.css
+++ b/src/popup.css
@@ -206,7 +206,7 @@ img#addIcon:hover {
     background-color: var(--surface-container-color);
 }
 
-.workspace-current {
+.workspace-open {
     font-weight: 700;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,24 @@ export class Utils {
     }
 
     /**
+     * Retrieves all Chrome window IDs.
+     * @returns A Promise that resolves with an array of window IDs.
+     */
+    public static async getAllWindowIds(): Promise<(number | undefined)[]> {
+        return new Promise((resolve) => {
+            chrome.windows.getAll().then((windows) => {
+                const windowIds = windows.map((window) => window.id);
+                resolve(windowIds);
+            })
+                // If the windows are not found, the promise will still resolve, just with an empty array.
+                // Catch the error to prevent the console from logging it.
+                .catch(() => {
+                    resolve([]);
+                });
+        });
+    }
+
+    /**
      * Focuses a Chrome window by its ID.
      * @param windowId - The ID of the window to focus.
      */

--- a/src/workspace-entry-logic.ts
+++ b/src/workspace-entry-logic.ts
@@ -10,7 +10,7 @@ import { WorkspaceStorage } from "./workspace-storage";
  */
 export class WorkspaceEntryLogic {
 
-    public static listWorkspaces(workspaces: WorkspaceStorage, curOpenWorkspace: Workspace | undefined = undefined) {
+    public static listWorkspaces(workspaces: WorkspaceStorage, allWindowIds: (number | undefined)[]) {
         console.debug("listWorkspaces", workspaces)
 
         const workspaceDiv = document.getElementById("workspaces-list");
@@ -19,7 +19,7 @@ export class WorkspaceEntryLogic {
             return;
         }
         workspaceDiv.innerHTML = "";
-
+        
         // Add each workspace to the list, and add event listeners to the buttons.
         for (const workspace of Array.from(workspaces.values())) {
             const workspaceElement = this.addWorkspace(workspaceDiv, workspace);
@@ -28,20 +28,13 @@ export class WorkspaceEntryLogic {
             const editWorkspace = workspaceElement.querySelector('#edit-button');
             const deleteWorkspace = workspaceElement.querySelector('#delete-button');
 
-            // Add a class to the workspace if this window is the current workspace.
-            if (curOpenWorkspace?.uuid === workspace.uuid) {
-                workspaceElement.classList.add('workspace-current');
+            // Add a class to the workspace if it is open in a window.
+            if (allWindowIds?.includes(workspace.windowId)) {
+                workspaceElement.classList.add('workspace-open');
             }
-            else {
-                // Don't allow the user to re-open the current workspace.
-                openWorkspace?.addEventListener('click', () => {
-                    this.workspaceClicked(workspace);
-                });
-            }
-
-            // settingsWorkspace?.addEventListener('click', () => {
-            //     this.workspaceSettingsClicked(workspace);
-            // });
+            openWorkspace?.addEventListener('click', () => {
+                this.workspaceClicked(workspace);
+            });
 
             editWorkspace?.addEventListener('click', (event) => {
                 event.stopPropagation();
@@ -125,11 +118,5 @@ export class WorkspaceEntryLogic {
             return;
         }
         PopupActions.deleteWorkspace(workspace);
-    }
-
-    public static async tabRemoved(tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) {
-    }
-
-    public static async tabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
     }
 }

--- a/src/workspace-entry-logic.ts
+++ b/src/workspace-entry-logic.ts
@@ -29,7 +29,7 @@ export class WorkspaceEntryLogic {
             const deleteWorkspace = workspaceElement.querySelector('#delete-button');
 
             // Add a class to the workspace if it is open in a window.
-            if (allWindowIds?.includes(workspace.windowId)) {
+            if (allWindowIds.includes(workspace.windowId)) {
                 workspaceElement.classList.add('workspace-open');
             }
             openWorkspace?.addEventListener('click', () => {


### PR DESCRIPTION
Instead of showing only the current workspace as bold, now it shows all currently open workspaces as bold.
This should allow for easier at-a-glance navigation.

Additionally, the 'Add workspace' and 'Settings' buttons are now available in all instances of the extension popup.

Closes #30 #36 